### PR TITLE
fix: fix security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@commercelayer/sdk": "^6.58.0",
     "@oclif/core": "^3.27.0",
     "inquirer": "^8.2.7",
-    "json-2-csv": "^3.20.0",
+    "json-2-csv": "^5.5.11",
     "node-notifier": "^10.0.1",
     "open": "^8.4.2",
     "tslib": "^2.8.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  uuid@<11.1.1: ^11.1.1
+  serialize-javascript@<7.0.5: ^7.1.0
+  diff@<8.0.3: ^8.0.4
+
 importers:
 
   .:
@@ -24,8 +29,8 @@ importers:
         specifier: ^8.2.7
         version: 8.2.7(@types/node@25.9.5)
       json-2-csv:
-        specifier: ^3.20.0
-        version: 3.20.0
+        specifier: ^5.5.11
+        version: 5.5.11
       node-notifier:
         specifier: ^10.0.1
         version: 10.0.1
@@ -1343,9 +1348,9 @@ packages:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
 
-  deeks@2.6.1:
-    resolution: {integrity: sha512-PZrpz5xLo2JPZa3L+kqMMMdZU5pRwMysTM1xd6pLhNtgQw4Iq3wbF2QWaQTVh+HRq9Yg4rcjDIJ+scfGLxmsjQ==}
-    engines: {node: '>= 12'}
+  deeks@3.2.1:
+    resolution: {integrity: sha512-D/o0k3pCG1aI1cxb/dDiWmtMc4Rh7ZQBybXpfMsw9Rbtqwg8kUA9SpYkWcw0pAUjZSnPm8MluctiS0o68r69jQ==}
+    engines: {node: '>= 16'}
 
   deep-eql@4.1.4:
     resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
@@ -1370,21 +1375,17 @@ packages:
     resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
     engines: {node: '>=8'}
 
-  diff@5.2.2:
-    resolution: {integrity: sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==}
-    engines: {node: '>=0.3.1'}
-
-  diff@7.0.0:
-    resolution: {integrity: sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==}
+  diff@8.0.4:
+    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
 
-  doc-path@3.1.0:
-    resolution: {integrity: sha512-Pv2hLQbUM8du5681lTWIYk0OtVBmNhMAeZNGeFhMMJBIR89Nw4XesBwee1Xtlfk83n71tn0Y6VsJOn4d3qIiTw==}
-    engines: {node: '>=12'}
+  doc-path@4.1.4:
+    resolution: {integrity: sha512-yw5D++UCIB6a033PvQaUvSpW2QuKW0+DOId763n0Q4z3brxS7G8oQr8yBQ1nQFkognKrAVrV6I55TLeU9cfXTg==}
+    engines: {node: '>=16'}
 
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
@@ -2014,10 +2015,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  json-2-csv@3.20.0:
-    resolution: {integrity: sha512-IbqUB+yaycVNB/q2fiY5kyRjy5kRiEXqvNvGlxM5L0Bfi0RdvklVHc4t9MfeYF1GsZVpZWDBs9LdWmSjsQ8jvg==}
-    engines: {node: '>= 12'}
-    deprecated: A security vulnerability has been reported with the preventCsvInjection option which has been fixed in version 5.5.11. Please upgrade as soon as possible.
+  json-2-csv@5.5.11:
+    resolution: {integrity: sha512-kVuwgVL7rfad9ETf02ZZxJPuMR5ZSUn139+T34BfmVxYhb/IsAIm/LzEeQ8YLJmXfuQ5z7LUAFrgPZZM6VLJPw==}
+    engines: {node: '>= 16'}
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -2649,9 +2649,6 @@ packages:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
 
-  randombytes@2.1.0:
-    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
-
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
@@ -2781,8 +2778,9 @@ packages:
   sentence-case@3.0.4:
     resolution: {integrity: sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==}
 
-  serialize-javascript@6.0.2:
-    resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
+  serialize-javascript@7.1.0:
+    resolution: {integrity: sha512-RNEqWOyhhUQYN9V1GfHwu9AR/g+NTciH6Z5u3/no6X3/w+04J2lVDL+svFQVXgXrEGBMG2puMVN3gq2SNGuTGw==}
+    engines: {node: '>=20.0.0'}
 
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
@@ -3135,9 +3133,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   validate-npm-package-license@3.0.4:
@@ -4732,7 +4729,7 @@ snapshots:
     dependencies:
       mimic-response: 3.1.0
 
-  deeks@2.6.1: {}
+  deeks@3.2.1: {}
 
   deep-eql@4.1.4:
     dependencies:
@@ -4752,15 +4749,13 @@ snapshots:
 
   define-lazy-prop@2.0.0: {}
 
-  diff@5.2.2: {}
-
-  diff@7.0.0: {}
+  diff@8.0.4: {}
 
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
 
-  doc-path@3.1.0: {}
+  doc-path@4.1.4: {}
 
   dot-case@3.0.4:
     dependencies:
@@ -5427,10 +5422,10 @@ snapshots:
 
   jsesc@3.1.0: {}
 
-  json-2-csv@3.20.0:
+  json-2-csv@5.5.11:
     dependencies:
-      deeks: 2.6.1
-      doc-path: 3.1.0
+      deeks: 3.2.1
+      doc-path: 4.1.4
 
   json-buffer@3.0.1: {}
 
@@ -5628,7 +5623,7 @@ snapshots:
       browser-stdout: 1.3.1
       chokidar: 4.0.3
       debug: 4.4.3(supports-color@8.1.1)
-      diff: 7.0.0
+      diff: 8.0.4
       escape-string-regexp: 4.0.0
       find-up: 5.0.0
       glob: 10.5.0
@@ -5639,7 +5634,7 @@ snapshots:
       minimatch: 9.0.9
       ms: 2.1.3
       picocolors: 1.1.1
-      serialize-javascript: 6.0.2
+      serialize-javascript: 7.1.0
       strip-json-comments: 3.1.1
       supports-color: 8.1.1
       workerpool: 9.3.4
@@ -5709,7 +5704,7 @@ snapshots:
       is-wsl: 2.2.0
       semver: 7.8.5
       shellwords: 0.1.1
-      uuid: 8.3.2
+      uuid: 11.1.1
       which: 2.0.2
 
   node-preload@0.2.1:
@@ -6027,10 +6022,6 @@ snapshots:
 
   quick-lru@5.1.1: {}
 
-  randombytes@2.1.0:
-    dependencies:
-      safe-buffer: 5.2.1
-
   rc@1.2.8:
     dependencies:
       deep-extend: 0.6.0
@@ -6195,9 +6186,7 @@ snapshots:
       tslib: 2.8.1
       upper-case-first: 2.0.2
 
-  serialize-javascript@6.0.2:
-    dependencies:
-      randombytes: 2.1.0
+  serialize-javascript@7.1.0: {}
 
   set-blocking@2.0.0: {}
 
@@ -6228,7 +6217,7 @@ snapshots:
       '@sinonjs/commons': 3.0.1
       '@sinonjs/fake-timers': 10.3.0
       '@sinonjs/samsam': 8.0.3
-      diff: 5.2.2
+      diff: 8.0.4
       nise: 5.1.9
       supports-color: 7.2.0
 
@@ -6539,7 +6528,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@8.3.2: {}
+  uuid@11.1.1: {}
 
   validate-npm-package-license@3.0.4:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,12 @@
 allowBuilds:
   esbuild: true
+
+# Security overrides: transitive dependencies whose parents still pin a
+# vulnerable range upstream. Remove each entry once the parent releases a fix.
+overrides:
+  # GHSA-w5hq-g745-h8pq - node-notifier@10.0.1 (latest) pins uuid ^8.3.2
+  uuid@<11.1.1: ^11.1.1
+  # GHSA RCE + DoS - mocha pins serialize-javascript ^6.0.2
+  serialize-javascript@<7.0.5: ^7.1.0
+  # jsdiff DoS in parsePatch/applyPatch - mocha pins diff ^7.0.0, sinon pins ^5.0.0
+  diff@<8.0.3: ^8.0.4

--- a/src/csv.ts
+++ b/src/csv.ts
@@ -2,7 +2,7 @@
 
 import { writeFileSync } from 'node:fs'
 import { clOutput, type KeyValString } from '@commercelayer/cli-core'
-import { json2csvAsync } from 'json-2-csv'
+import { json2csv } from 'json-2-csv'
 
 
 
@@ -86,7 +86,7 @@ const exportCsv = async (output: any, flags: any, path: string): Promise<boolean
   if (delimiter && (delimiter === 'TAB')) delimiter = '\t'
 
 
-  await json2csvAsync(output, {
+  const csv = json2csv(output, {
     excelBOM: true,
     expandArrayObjects: true,
     prependHeader: true,
@@ -99,11 +99,9 @@ const exportCsv = async (output: any, flags: any, path: string): Promise<boolean
     delimiter: {
       field: delimiter,
     },
-  }).then(csv => {
-    writeFileSync(path, csv)
-  }).catch(error => {
-    throw error
   })
+
+  writeFileSync(path, csv)
 
   return await Promise.resolve(true)
 


### PR DESCRIPTION
## Fix security vulnerabilities

Resolves the open Dependabot/Vanta alerts on this repo, plus the remaining advisories surfaced by `pnpm audit`.

> **Why a new PR:** these changes were originally pushed to `update-dependencies` after #134 had already been merged, so they never reached `main`. GitHub does not reopen a merged PR when new commits land on its branch, which left the fix stranded on the branch while the alerts stayed open.

### Alerts closed by this PR

| Alert | Severity | Package | Vulnerable range | Fix |
| --- | --- | --- | --- | --- |
| [#98](https://github.com/commercelayer/commercelayer-cli-plugin-resources/security/dependabot/98), [#99](https://github.com/commercelayer/commercelayer-cli-plugin-resources/security/dependabot/99) | Medium | `json-2-csv` | `>= 3.15.0, < 5.5.11` (GHSA-g27c-q7cp-mhx6, CSV injection) | direct dependency bumped -> 5.5.11 |
| [#81](https://github.com/commercelayer/commercelayer-cli-plugin-resources/security/dependabot/81) | Medium | `uuid` | `< 11.1.1` (GHSA-w5hq-g745-h8pq) | override -> 11.1.1 |

### Additional advisories from `pnpm audit`

| Severity | Package | Issue | Path | Fix |
| --- | --- | --- | --- | --- |
| High | `serialize-javascript` 6.0.2 | RCE via `RegExp.flags` / `Date.prototype.toISOString()`, plus CPU-exhaustion DoS | `mocha` | override -> 7.1.0 |
| Low | `diff` 5.2.2 / 7.0.0 | jsdiff DoS in `parsePatch`/`applyPatch` | `mocha`, `sinon` | override -> 8.0.4 |

### `json-2-csv` 3 -> 5 (the one code change)

This is the only advisory that required touching application code. The fix landed in 5.5.11, so there is no patch available on the 3.x line.

The v4 major removed the promise-based `json2csvAsync` in favour of a synchronous `json2csv(data, options): string`, so `src/csv.ts` was adapted:

```diff
-import { json2csvAsync } from 'json-2-csv'
+import { json2csv } from 'json-2-csv'
...
-  await json2csvAsync(output, { ... }).then(csv => {
-    writeFileSync(path, csv)
-  }).catch(error => {
-    throw error
-  })
+  const csv = json2csv(output, { ... })
+
+  writeFileSync(path, csv)
```

`exportCsv` keeps its `async` signature and its `Promise<boolean>` return, so every caller is unaffected. Errors now propagate directly instead of through the `.catch(error => { throw error })` re-throw, which was a no-op.

Every option the plugin passes (`excelBOM`, `expandArrayObjects`, `prependHeader`, `sortHeader`, `unwindArrays`, `useDateIso8601Format`, `emptyFieldValue`, `keys`, `delimiter.field`) still exists in v5 with the same semantics.

**Output verified identical.** Running v3.20.0 and v5.5.11 side by side over the same records and the exact option set used by the plugin produces byte-identical CSV — BOM, header renaming via `keys[].title`, quoting of embedded commas and double quotes, empty-value substitution, array unwinding, ISO dates and negative numbers all match:

```
id,SKU Code,name,created_at,pieces_per_pack,empty,do_not_ship,metadata.foo,prices.amount_cents
ABC123,TSHIRT-1,"T-Shirt, black",2026-01-15T10:30:00.000Z,3,,false,bar; baz,-500
DEF456,MUG,"Mug ""large""",2026-02-01T08:00:00.000Z,,,true,,1200
DEF456,MUG,"Mug ""large""",2026-02-01T08:00:00.000Z,,,true,,999
```

Note the advisory concerns the `preventCsvInjection` option not fully sanitising injected formulas. The plugin never enables that option, so it was not relying on the broken behaviour. I deliberately did **not** turn it on: it left-trims `=`, `+`, `-`, `@` from values, which would corrupt legitimate exported data such as negative `amount_cents`. Worth a separate discussion if CSV injection hardening is wanted.

### Overrides

`uuid`, `serialize-javascript` and `diff` sit behind parents that still pin a vulnerable range, with no upstream release that fixes them:

- `node-notifier@10.0.1` is the latest release and pins `uuid ^8.3.2`
- `mocha` pins `serialize-javascript ^6.0.2` and `diff ^7.0.0`
- `sinon` (via `@oclif/test`) pins `diff ^5.0.0`

They are declared in `pnpm-workspace.yaml`, since pnpm 11 no longer reads `pnpm.overrides` from `package.json`. Each entry is scoped to the vulnerable range only (`uuid@<11.1.1`) and carries a comment with the reason, so it drops out naturally once the parent ships a fix.

Compatibility of the overridden majors:

- **`uuid` 8 -> 11**: `node-notifier` uses uuid in exactly one place, `notifiers/toaster.js` (`const { v4: uuid } = require('uuid')`), the Windows toaster path. uuid 11 still ships a CJS build and still exports `v4`. The advisory itself is not reachable here — it concerns `v3`/`v5`/`v6` called with a `buf` argument, and node-notifier only calls `v4()` with no arguments.
- **`serialize-javascript` 6 -> 7**: dev-only (mocha parallel-mode worker serialization). v7 requires Node >= 20, which matches this package's `engines`.
- **`diff` 7 -> 8**: dev-only (mocha's `base` reporter uses `createPatch`, sinon uses it for assertion diffs). v8 keeps the CJS entry point and the APIs both consumers call.

### Verification

- `pnpm audit` — no advisories
- `pnpm build`, `pnpm test` (15 passing), `pnpm lint` (biome, 48 files) — all pass
- `exportCsv` exercised end to end against the built `lib/`, writing a real file: BOM, header aliasing, quoting and unwinding all correct
- v3 vs v5 output diffed and found identical (above)
- CLI smoke-tested via `./bin/run.js`
